### PR TITLE
feat: real gas cost metering

### DIFF
--- a/src/StdGas.sol
+++ b/src/StdGas.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
+import {VmSafe} from "./Vm.sol";
+import {console} from "./console.sol";
+
+abstract contract StdGas {
+    VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    // Stores the storage slots that have been accessed before the last recording.
+    mapping(address => mapping(bytes32 => bool)) private accessed;
+
+    // Gas left when the metering started.
+    uint256 gasLeftAtStart;
+
+    function startGasMetering() internal {
+        // Store gas left before recording.
+        gasLeftAtStart = gasleft();
+        // Clear accesses list.
+        vm.record();
+        // Start gas metering.
+        vm.resumeGasMetering();
+    }
+
+    /// @notice Returns the gas consumed during the recording, if what it 
+    /// happened as a transaction on its own.
+    /// @dev 2100 is added to the total gas cost for all SLOAD and SSTORE if the 
+    /// slot has been accessed before in this test (in `accessed`) and not 
+    /// already accessed during this recording.
+    function stopGasMetering() internal returns (uint256) {
+        vm.pauseGasMetering();
+
+        uint256 gasLeft = gasleft();
+
+        // Retrieve slots accessed during the last recording.
+        bytes32[] memory slots = _accessedDuringRecording();
+
+        // Compute total gas spent.
+        uint256 gasConsumed = gasLeftAtStart - gasLeft;
+
+        for (uint256 i; i < slots.length; i++) {
+            // If the slot was warm, but shouldn't have been.
+            if (accessed[address(this)][slots[i]]) {
+                // Compensate for false warm slot.
+                gasConsumed += 2100;
+            }
+            // Store accessed slot, such that next time it is accessed, the
+            // compensation can be added.
+            accessed[address(this)][slots[i]] = true;
+        }
+
+        return gasConsumed;
+    }
+
+    // Helpers for `_accessedDuringRecording`.
+    mapping(bytes32 => bool) private accessedTemp;
+    bytes32[] private slotsTemp;
+
+    /// @notice Returns all slots accessed during the last recording.
+    /// @dev Concatenates all accesses and removes duplicates (which are not
+    // needed because we don't need to compensate for their warm access).
+    function _accessedDuringRecording() private returns (bytes32[] memory) {
+        // Retrive all accesses (read an write).
+        (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(address(this));
+
+        // Concatenate `reads` and `writes` and remove duplicates.
+        for (uint256 i; i < reads.length; i++) {
+            if (!accessedTemp[reads[i]]) {
+                accessedTemp[reads[i]] = true;
+                slotsTemp.push(reads[i]);
+            }
+        }
+        for (uint256 i; i < writes.length; i++) {
+            if (!accessedTemp[writes[i]]) {
+                accessedTemp[writes[i]] = true;
+                slotsTemp.push(writes[i]);
+            }
+        }
+
+        bytes32[] memory slots = slotsTemp;
+
+        // Clear temporary mapping.
+        for (uint256 i; i < slotsTemp.length; i++) {
+            accessedTemp[slotsTemp[i]] = false;
+        }
+        // Clear temporary array.
+        slotsTemp = new bytes32[](0);
+
+        return slots;
+    }
+}

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -11,6 +11,7 @@ import {StdAssertions} from "./StdAssertions.sol";
 import {StdChains} from "./StdChains.sol";
 import {StdCheats} from "./StdCheats.sol";
 import {stdError} from "./StdError.sol";
+import {StdGas} from "./StdGas.sol";
 import {stdJson} from "./StdJson.sol";
 import {stdMath} from "./StdMath.sol";
 import {StdStorage, stdStorage} from "./StdStorage.sol";
@@ -22,7 +23,7 @@ import {TestBase} from "./Base.sol";
 import {DSTest} from "ds-test/test.sol";
 
 // ⭐️ TEST
-abstract contract Test is DSTest, StdAssertions, StdChains, StdCheats, StdUtils, TestBase {
+abstract contract Test is DSTest, StdAssertions, StdChains, StdCheats, StdGas, StdUtils, TestBase {
 // Note: IS_TEST() must return true.
 // Note: Must have failure system, https://github.com/dapphub/ds-test/blob/cd98eff28324bfac652e63a239a60632a761790b/src/test.sol#L39-L76.
 }

--- a/test/StdGas.t.sol
+++ b/test/StdGas.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../src/Test.sol";
+
+contract StdGasTest is Test {
+    // Base cost of `startGasMetering` and `stopGasMetering`.
+    uint256 internal constant baseCost = 536;
+    // Opcodes gas cost.
+    uint256 internal constant PUSH = 3;
+    uint256 internal constant SSTORE = 100;
+    uint256 internal constant COLD_SSTORE = 2200;
+    uint256 internal constant COLD_UNZEROED_SSTORE = 22100;
+
+    function testGasMeteringEmpty() public noGasMetering {
+        startGasMetering();
+        uint256 gasConsumed = stopGasMetering();
+
+        assertEq(gasConsumed, baseCost);
+    }
+
+    function testGasMeteringColdSSTORE() public noGasMetering {
+        startGasMetering();
+        assembly {
+            sstore(0xffff, 0)
+        }
+        uint256 gasConsumed = stopGasMetering();
+
+        assertEq(gasConsumed, COLD_SSTORE + PUSH + PUSH + baseCost);
+    }
+
+    function testGasMeteringWarmSSTORE() public noGasMetering {
+        startGasMetering();
+        assembly {
+            // Store a first time in 0xffff to make the slot warm.
+            sstore(0xffff, 1)
+        }
+        uint256 gasConsumed = stopGasMetering();
+
+        assertEq(gasConsumed, COLD_UNZEROED_SSTORE + PUSH + PUSH + baseCost);
+
+        startGasMetering();
+        assembly {
+            // Store again in 0xffff, we expect a false-warm-slot compensation.
+            sstore(0xffff, 2)
+        }
+        gasConsumed = stopGasMetering();
+
+        // We expect it to be as if the slot was cold (also one less push).
+        assertEq(gasConsumed, COLD_SSTORE + PUSH + baseCost);
+    }
+}


### PR DESCRIPTION
Helper to calculate the "real" gas cost some Solidity code. 

It adds the access cost of cold storage slot to the slots that would have been cold if the sequence was done in a transaction on its own (outside of the test).

TODO:
- [ ] manage any address
- [ ] handle addresses automatically
- [ ] manage cold/warm addresses (CALL opcode)